### PR TITLE
tweaked sbt settings to make build possible using sbt0.13.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import AssemblyKeys._
-
 organization  := "org.apache.kafka"
 
 name          := "udp-kafka-bridge"
@@ -27,5 +25,3 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"       %%  "akka-testkit"     % "2.2.1"  % "test",
   "org.specs2"              %%  "specs2"           % "2.2"    % "test"
 )
-
-assemblySettings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.3
+sbt.version=0.13.9
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
 


### PR DESCRIPTION
I use ubuntu 14.04 LTS with sbt 0.13.9 with scala 2.11.5
I was running into build issues with some discrepancies due to how the [assembly plugin has changed](https://github.com/sbt/sbt-assembly/blob/master/Migration.md#upgrading-with-bare-buildsbt). 

This request fixes those issues.
